### PR TITLE
`/docs/reference/text/sub`および`/docs/reference/text/super`の翻訳

### DIFF
--- a/crates/typst-library/src/text/shift.rs
+++ b/crates/typst-library/src/text/shift.rs
@@ -7,21 +7,20 @@ use crate::layout::{Em, Length};
 use crate::text::{variant, SpaceElem, TextElem, TextSize};
 use crate::World;
 
-/// Renders text in subscript.
+/// テキストを下付き文字でレンダリング。
 ///
-/// The text is rendered smaller and its baseline is lowered.
+/// テキストは小さくレンダリングされ、ベースラインは低くなります。
 ///
-/// # Example
+/// # 例
 /// ```example
 /// Revenue#sub[yearly]
 /// ```
 #[elem(title = "Subscript", Show)]
 pub struct SubElem {
-    /// Whether to prefer the dedicated subscript characters of the font.
+    /// フォントの下付き文字専用の字形を優先するかどうか。
     ///
-    /// If this is enabled, Typst first tries to transform the text to subscript
-    /// codepoints. If that fails, it falls back to rendering lowered and shrunk
-    /// normal letters.
+    /// 有効化された場合、Typstは最初にテキストを下付き文字のコードポイントに変換できるか試します。
+    /// 失敗した場合は、通常の文字を縮小し、位置を下げる挙動にフォールバックします。
     ///
     /// ```example
     /// N#sub(typographic: true)[1]
@@ -30,19 +29,17 @@ pub struct SubElem {
     #[default(true)]
     pub typographic: bool,
 
-    /// The baseline shift for synthetic subscripts. Does not apply if
-    /// `typographic` is true and the font has subscript codepoints for the
-    /// given `body`.
+    /// 下付き文字の合成に用いるベースラインのシフト。
+    /// `typographic`がtrueかつフォントが与えられた`body`に対して下付き文字のコードポイントを持っている場合は使用しないでください。
     #[default(Em::new(0.2).into())]
     pub baseline: Length,
 
-    /// The font size for synthetic subscripts. Does not apply if
-    /// `typographic` is true and the font has subscript codepoints for the
-    /// given `body`.
+    /// 下付き文字の合成に用いるフォントの大きさ。
+    /// `typographic`がtrueかつフォントが与えられた`body`に対して下付き文字のコードポイントを持っている場合は使用しないでください。
     #[default(TextSize(Em::new(0.6).into()))]
     pub size: TextSize,
 
-    /// The text to display in subscript.
+    /// 下付き文字で表示するテキスト。
     #[required]
     pub body: Content,
 }

--- a/crates/typst-library/src/text/shift.rs
+++ b/crates/typst-library/src/text/shift.rs
@@ -63,21 +63,20 @@ impl Show for Packed<SubElem> {
     }
 }
 
-/// Renders text in superscript.
+/// テキストを上付き文字でレンダリング。
 ///
-/// The text is rendered smaller and its baseline is raised.
+/// テキストは小さくレンダリングされ、ベースラインは高くなります。
 ///
-/// # Example
+/// # 例
 /// ```example
 /// 1#super[st] try!
 /// ```
 #[elem(title = "Superscript", Show)]
 pub struct SuperElem {
-    /// Whether to prefer the dedicated superscript characters of the font.
+    /// フォントの上付き文字専用の字形を優先するかどうか。
     ///
-    /// If this is enabled, Typst first tries to transform the text to
-    /// superscript codepoints. If that fails, it falls back to rendering
-    /// raised and shrunk normal letters.
+    /// 有効化された場合、Typstは最初にテキストを上付き文字のコードポイントに変換できるか試します。
+    /// 失敗した場合は、通常の文字を縮小し、位置を上げる挙動にフォールバックします。
     ///
     /// ```example
     /// N#super(typographic: true)[1]
@@ -86,19 +85,17 @@ pub struct SuperElem {
     #[default(true)]
     pub typographic: bool,
 
-    /// The baseline shift for synthetic superscripts. Does not apply if
-    /// `typographic` is true and the font has superscript codepoints for the
-    /// given `body`.
+    /// 上付き文字の合成に用いるベースラインのシフト。
+    /// `typographic`がtrueかつフォントが与えられた`body`に対して上付き文字のコードポイントを持っている場合は使用しないでください。
     #[default(Em::new(-0.5).into())]
     pub baseline: Length,
 
-    /// The font size for synthetic superscripts. Does not apply if
-    /// `typographic` is true and the font has superscript codepoints for the
-    /// given `body`.
+    /// 上付き文字の合成に用いるフォントの大きさ。
+    /// `typographic`がtrueかつフォントが与えられた`body`に対して上付き文字のコードポイントを持っている場合は使用しないでください。
     #[default(TextSize(Em::new(0.6).into()))]
     pub size: TextSize,
 
-    /// The text to display in superscript.
+    /// 上付き文字で表示するテキスト。
     #[required]
     pub body: Content,
 }

--- a/crates/typst-library/src/text/shift.rs
+++ b/crates/typst-library/src/text/shift.rs
@@ -30,12 +30,12 @@ pub struct SubElem {
     pub typographic: bool,
 
     /// 下付き文字の合成に用いるベースラインのシフト。
-    /// `typographic`がtrueかつフォントが与えられた`body`に対して下付き文字のコードポイントを持っている場合は使用しないでください。
+    /// `typographic`がtrueかつ与えられた`body`に対してフォントが下付き文字のコードポイントを持っている場合は適用されません。
     #[default(Em::new(0.2).into())]
     pub baseline: Length,
 
     /// 下付き文字の合成に用いるフォントの大きさ。
-    /// `typographic`がtrueかつフォントが与えられた`body`に対して下付き文字のコードポイントを持っている場合は使用しないでください。
+    /// `typographic`がtrueかつ与えられた`body`に対してフォントが下付き文字のコードポイントを持っている場合は適用されません。
     #[default(TextSize(Em::new(0.6).into()))]
     pub size: TextSize,
 
@@ -86,12 +86,12 @@ pub struct SuperElem {
     pub typographic: bool,
 
     /// 上付き文字の合成に用いるベースラインのシフト。
-    /// `typographic`がtrueかつフォントが与えられた`body`に対して上付き文字のコードポイントを持っている場合は使用しないでください。
+    /// `typographic`がtrueかつ与えられた`body`に対してフォントが上付き文字のコードポイントを持っている場合は適用されません。
     #[default(Em::new(-0.5).into())]
     pub baseline: Length,
 
     /// 上付き文字の合成に用いるフォントの大きさ。
-    /// `typographic`がtrueかつフォントが与えられた`body`に対して上付き文字のコードポイントを持っている場合は使用しないでください。
+    /// `typographic`がtrueかつ与えられた`body`に対してフォントが上付き文字のコードポイントを持っている場合は適用されません。
     #[default(TextSize(Em::new(0.6).into()))]
     pub size: TextSize,
 

--- a/website/translation-status.json
+++ b/website/translation-status.json
@@ -73,7 +73,7 @@
 	"/docs/reference/text/smartquote/": "untranslated",
 	"/docs/reference/text/strike/": "translated",
 	"/docs/reference/text/sub/": "translated",
-	"/docs/reference/text/super/": "untranslated",
+	"/docs/reference/text/super/": "translated",
 	"/docs/reference/text/text/": "untranslated",
 	"/docs/reference/text/underline/": "translated",
 	"/docs/reference/text/upper/": "translated",

--- a/website/translation-status.json
+++ b/website/translation-status.json
@@ -72,7 +72,7 @@
 	"/docs/reference/text/smallcaps/": "translated",
 	"/docs/reference/text/smartquote/": "untranslated",
 	"/docs/reference/text/strike/": "translated",
-	"/docs/reference/text/sub/": "untranslated",
+	"/docs/reference/text/sub/": "translated",
 	"/docs/reference/text/super/": "untranslated",
 	"/docs/reference/text/text/": "untranslated",
 	"/docs/reference/text/underline/": "translated",


### PR DESCRIPTION
[text/sub](https://typst.app/docs/reference/text/sub)および[text/super](https://typst.app/docs/reference/text/super)の翻訳です。