### PR TITLE
Fix broken links

### DIFF
--- a/docs/changelog/0.10.0.md
+++ b/docs/changelog/0.10.0.md
@@ -31,7 +31,7 @@ description: Changes in Typst 0.10.0
 - More LaTeX commands (e.g. for quotes) are now respected in `.bib` files
 
 ## Visualization
-- Added support for [patterns]($pattern) as fills and strokes
+- Added support for [patterns]($tiling) as fills and strokes
 - The `alpha` parameter of the [`components`]($color.components) function on
   colors is now a named parameter **(Breaking change)**
 - Added support for the [Oklch]($color.oklch) color space

--- a/docs/changelog/0.11.1.md
+++ b/docs/changelog/0.11.1.md
@@ -37,7 +37,7 @@ description: Changes in Typst 0.11.1
 
 ## Export
 - Fixed [smart quotes]($smartquote) in PDF outline
-- Fixed [patterns]($pattern) with spacing in PDF
+- Fixed [patterns]($tiling) with spacing in PDF
 - Fixed wrong PDF page labels when [page numbering]($page.numbering) was
   disabled after being previously enabled
 

--- a/docs/reference/language/syntax.md
+++ b/docs/reference/language/syntax.md
@@ -105,18 +105,18 @@ Typstは、最も一般的な文書要素に対する組み込みのマークア
 | コードブロック             | `{{ let x = 1; x + 2 }}`      | [Scripting]($scripting/#blocks)       |
 | コンテンツブロック         | `{[*Hello*]}`                 | [Scripting]($scripting/#blocks)       |
 | 括弧付き式                 | `{(1 + 2)}`                   | [Scripting]($scripting/#blocks)       |
-| 配列                       | `{(1, 2, 3)}`                 | [Array]($type/$array)                 |
-| 辞書                       | `{(a: "hi", b: 2)}`           | [Dictionary]($type/$dictionary)       |
+| 配列                       | `{(1, 2, 3)}`                 | [Array]($array)                 |
+| 辞書                       | `{(a: "hi", b: 2)}`           | [Dictionary]($dictionary)       |
 | 単項演算子                 | `{-x}`                        | [Scripting]($scripting/#operators)    |
 | 二項演算子                 | `{x + y}`                     | [Scripting]($scripting/#operators)    |
 | 代入                       | `{x = 1}`                     | [Scripting]($scripting/#operators)    |
 | フィールドアクセス         | `{x.y}`                       | [Scripting]($scripting/#fields)       |
 | メソッド呼び出し           | `{x.flatten()}`               | [Scripting]($scripting/#methods)      |
-| 関数呼び出し               | `{min(x, y)}`                 | [Function]($type/$function)           |
-| 引数展開                   | `{min(..nums)}`               | [Arguments]($type/$arguments)         |
-| 無名関数                   | `{(x, y) => x + y}`           | [Function]($type/$function)           |
+| 関数呼び出し               | `{min(x, y)}`                 | [Function]($function)           |
+| 引数展開                   | `{min(..nums)}`               | [Arguments]($arguments)         |
+| 無名関数                   | `{(x, y) => x + y}`           | [Function]($function)           |
 | letバインディング          | `{let x = 1}`                 | [Scripting]($scripting/#bindings)     |
-| 名前付き関数               | `{let f(x) = 2 * x}`          | [Function]($type/$function)           |
+| 名前付き関数               | `{let f(x) = 2 * x}`          | [Function]($function)           |
 | setルール                  | `{set text(14pt)}`            | [Styling]($styling/#set-rules)        |
 | set-ifルール               | `{set text(..) if .. }`       | [Styling]($styling/#set-rules)        |
 | show-setルール             | `{show heading: set block(..)}` | [Styling]($styling/#show-rules)     |
@@ -127,7 +127,7 @@ Typstは、最も一般的な文書要素に対する組み込みのマークア
 | forループ                  | `{for x in (1, 2, 3) {..}}`   | [Scripting]($scripting/#loops)        |
 | whileループ                | `{while x < 10 {..}}`         | [Scripting]($scripting/#loops)        |
 | ループ制御フロー           | `{break, continue}`           | [Scripting]($scripting/#loops)        |
-| 関数からのリターン         | `{return x}`                  | [Function]($type/$function)           |
+| 関数からのリターン         | `{return x}`                  | [Function]($function)           |
 | モジュールをインクルード   | `{include "bar.typ"}`         | [Scripting]($scripting/#modules)      |
 | モジュールをインポート     | `{import "bar.typ"}`          | [Scripting]($scripting/#modules)      |
 | モジュールからのインポート | `{import "bar.typ": a, b, c}` | [Scripting]($scripting/#modules)      |


### PR DESCRIPTION
## fix: remove `$type/` prefixes in `syntax.md`

Before:
- `$type/$function`
  `reference/foundations/type/$function/`

After:
- `$function`
  `reference/foundations/function/`

You can refer to the [official `syntax.md`](https://github.com/typst/typst/blob/c7938e93dcd63464912345c3d7363f5961c2f47d/docs/reference/language/syntax.md?plain=1#L116) for reference.

`typst-docs` did not panic, because it thought things after `/` are `#`-anchors. (The normal usage would be `$scripting/#loops`.)

## fix: rename `$pattern` to `$tiling`

The page `$pattern` does not exist anymore.

See also https://typst.app/docs/changelog/0.11.1/#export for reference.
