### PR TITLE
docs: GitHubリポジトリのURLを移行先に置換

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -6,7 +6,7 @@ labels:
 body:
   - type: markdown
     attributes:
-      value: 翻訳ドキュメントの改善をご提案いただきありがとうございます。[Issueを作成する前に同様のIssueが既に存在しないかを確認してください。](https://github.com/typst-jp/typst-jp.github.io/issues?q=is%3Aopen)
+      value: 翻訳ドキュメントの改善をご提案いただきありがとうございます。[Issueを作成する前に同様のIssueが既に存在しないかを確認してください。](https://github.com/typst-jp/docs/issues?q=is%3Aopen)
   - type: textarea
     attributes:
       label: 対象ドキュメント

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://github.com/typst/typst
     about: 原文やTypst本体に対しての提案は公式のリポジトリにお問い合わせください。
   - name: その他の提案
-    url: https://github.com/typst-jp/typst-jp.github.io/issues/new
+    url: https://github.com/typst-jp/docs/issues/new
     about: 当てはまるものがない場合は、テンプレートを使用せずにIssueを作成できます。

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -6,7 +6,7 @@ labels:
 body:
   - type: markdown
     attributes:
-      value: 翻訳ドキュメントの新規追加をご提案いただきありがとうございます。[Issueを作成する前に同様のIssueが既に存在しないかを確認してください。](https://github.com/typst-jp/typst-jp.github.io/issues?q=is%3Aopen)
+      value: 翻訳ドキュメントの新規追加をご提案いただきありがとうございます。[Issueを作成する前に同様のIssueが既に存在しないかを確認してください。](https://github.com/typst-jp/docs/issues?q=is%3Aopen)
   - type: textarea
     attributes:
       label: 対象ドキュメント

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,12 +9,12 @@ Typst日本語ドキュメント翻訳プロジェクトにご興味をお持ち
 
 ## 翻訳の進め方
 
-翻訳は[GitHub上の当リポジトリ](https://github.com/typst-jp/typst-jp.github.io)を中心に行います。実際の翻訳作業やそれに対する議論や提案などは、主にGitHubの[Issue](https://github.com/typst-jp/typst-jp.github.io/issues)や[Pull Request](https://github.com/typst-jp/typst-jp.github.io/pulls)機能を通じて行います。また、[Discordサーバー「くみはんクラブ」](https://discord.gg/9xF7k4aAuH)の`#typst-翻訳`チャンネルでも、質問の対応などが可能です。
+翻訳は[GitHub上の当リポジトリ](https://github.com/typst-jp/docs)を中心に行います。実際の翻訳作業やそれに対する議論や提案などは、主にGitHubの[Issue](https://github.com/typst-jp/docs/issues)や[Pull Request](https://github.com/typst-jp/docs/pulls)機能を通じて行います。また、[Discordサーバー「くみはんクラブ」](https://discord.gg/9xF7k4aAuH)の`#typst-翻訳`チャンネルでも、質問の対応などが可能です。
 
 ### 翻訳提案の手順
 
 > [!WARNING]
-> ここに記載されている内容は改訂中です。現在の手順は最新の[Pull Request](https://github.com/typst-jp/typst-jp.github.io/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen)を参照してください。
+> ここに記載されている内容は改訂中です。現在の手順は最新の[Pull Request](https://github.com/typst-jp/docs/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen)を参照してください。
 
 1. このGitHubリポジトリをフォークします。
 2. ドキュメントの実体は、主にMarkdownファイルおよびコンパイラのソースコード内のコメントの2種類から構成されています。それぞれ、下記の注意書きに従って翻訳作業をお願いします。
@@ -35,7 +35,7 @@ Typst日本語ドキュメント翻訳プロジェクトにご興味をお持ち
 
 ### 技術的な詳細
 
-[`./website/`のREADME](https://github.com/typst-jp/typst-jp.github.io/blob/main/website/README.md)を参照してください。
+[`./website/`のREADME](https://github.com/typst-jp/docs/blob/main/website/README.md)を参照してください。
 
 ### ローカル環境でWebページを生成
 

--- a/README.en.md
+++ b/README.en.md
@@ -12,6 +12,6 @@ The actual working web version can be viewed at the following URL.
 
 ## How to participate in translation
 
-Please refer to the [Translation Guidelines (CONTRIBUTING.md)](CONTRIBUTING.md) and create a [Pull Request](https://github.com/typst-jp/typst-jp.github.io/pulls). Questions and discussions are also welcome in [Issues](https://github.com/typst-jp/typst-jp.github.io/issues).
+Please refer to the [Translation Guidelines (CONTRIBUTING.md)](CONTRIBUTING.md) and create a [Pull Request](https://github.com/typst-jp/docs/pulls). Questions and discussions are also welcome in [Issues](https://github.com/typst-jp/docs/issues).
 
 Also, feel free to join our Discord server [Kumihan Club](https://discord.gg/9xF7k4aAuH) to get in touch with us directly.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Typst 日本語ドキュメント (非公式)
 
-[![CI/CD for website](https://github.com/typst-jp/typst-jp.github.io/actions/workflows/website.yml/badge.svg?branch=main&event=push)](https://github.com/typst-jp/typst-jp.github.io/actions/workflows/website.yml)
+[![CI/CD for website](https://github.com/typst-jp/docs/actions/workflows/website.yml/badge.svg?branch=main&event=push)](https://github.com/typst-jp/docs/actions/workflows/website.yml)
 
 > [!NOTE]
 > For English version, please refer to [README.en.md](README.en.md).
@@ -14,7 +14,7 @@
 
 ## 翻訳に参加するには
 
-[貢献ガイドライン (CONTRIBUTING.md)](CONTRIBUTING.md) をご覧の上、[Pull Request](https://github.com/typst-jp/typst-jp.github.io/pulls) を作成してください。[Issue](https://github.com/typst-jp/typst-jp.github.io/issues)での質問や議論も歓迎します。
+[貢献ガイドライン (CONTRIBUTING.md)](CONTRIBUTING.md) をご覧の上、[Pull Request](https://github.com/typst-jp/docs/pulls) を作成してください。[Issue](https://github.com/typst-jp/docs/issues)での質問や議論も歓迎します。
 
 ご質問などがある場合は、[「くみはんクラブ」のDiscordサーバー](https://discord.gg/9xF7k4aAuH)に参加してご連絡ください。
 

--- a/website/src/metadata.ts
+++ b/website/src/metadata.ts
@@ -12,7 +12,7 @@ export const typstOfficialDocsUrl: `http://${string}/` | `https://${string}/` =
 export const githubOrganizationUrl = "https://github.com/typst-jp";
 /** The GitHub repository URL. */
 export const githubRepositoryUrl =
-	"https://github.com/typst-jp/typst-jp.github.io";
+	"https://github.com/typst-jp/docs";
 /** The Discord server invite URL. */
 export const discordServerUrl = "https://discord.gg/9xF7k4aAuH";
 /** The origin URL of the deployed site, used for metadata. Note that the base path should not be included. */

--- a/website/src/metadata.ts
+++ b/website/src/metadata.ts
@@ -11,8 +11,7 @@ export const typstOfficialDocsUrl: `http://${string}/` | `https://${string}/` =
 /** The GitHub organization URL. */
 export const githubOrganizationUrl = "https://github.com/typst-jp";
 /** The GitHub repository URL. */
-export const githubRepositoryUrl =
-	"https://github.com/typst-jp/docs";
+export const githubRepositoryUrl = "https://github.com/typst-jp/docs";
 /** The Discord server invite URL. */
 export const discordServerUrl = "https://discord.gg/9xF7k4aAuH";
 /** The origin URL of the deployed site, used for metadata. Note that the base path should not be included. */


### PR DESCRIPTION
cf. https://github.com/typst-jp/docs/issues/233#issuecomment-3216418382