### PR TITLE
`/docs/reference/data-loading/`の翻訳

### DIFF
--- a/docs/reference/library/data-loading.md
+++ b/docs/reference/library/data-loading.md
@@ -1,4 +1,4 @@
-Data loading from external files.
+外部ファイルからのデータの読み込み。
 
-These functions help you with loading and embedding data, for example from the
-results of an experiment.
+これらの関数は、
+例えば実験結果のようなデータの読み込みと埋め込みを支援します。

--- a/website/translation-status.json
+++ b/website/translation-status.json
@@ -151,7 +151,7 @@
 	"/docs/reference/introspection/metadata/": "untranslated",
 	"/docs/reference/introspection/query/": "untranslated",
 	"/docs/reference/introspection/state/": "untranslated",
-	"/docs/reference/data-loading/": "untranslated",
+	"/docs/reference/data-loading/": "translated",
 	"/docs/reference/data-loading/cbor/": "translated",
 	"/docs/reference/data-loading/csv/": "translated",
 	"/docs/reference/data-loading/json/": "translated",


### PR DESCRIPTION
[/data-loading](https://typst.app/docs/reference/data-loading/)の翻訳です。
プレビューでは定義セクションの一部が未訳になっていますが、他のPR(#280 ,#281 )がマージされたタイミングで和訳が反映されると思われます。