### PR TITLE
chore: use `basePath` from `metadata.json` for `mise run generate-docs`

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -8,8 +8,11 @@ pinact = "3.1.1"
 yes = true
 idiomatic_version_file_enable_tools = []
 
+[vars]
+_.file = "website/metadata.json"
+
 [tasks.generate-docs]
-run = "cargo run --package typst-docs -- --assets-dir assets --out-file docs.json --base /docs/"
+run = "cargo run --package typst-docs -- --assets-dir assets --out-file docs.json --base {{vars.basePath}}"
 
 [tasks.generate-web]
 depends = ["install-website"]


### PR DESCRIPTION
[`vars` can also be read in as a file. (mise.jdx.dev)](https://mise.jdx.dev/tasks/task-configuration.html#vars-options).

Continues #303.
Relates to #233.