### PR TITLE
`/docs/reference/png/`の翻訳

### DIFF
--- a/website/translation-status.json
+++ b/website/translation-status.json
@@ -164,7 +164,7 @@
 	"/docs/reference/html/": "untranslated",
 	"/docs/reference/html/elem/": "untranslated",
 	"/docs/reference/html/frame/": "untranslated",
-	"/docs/reference/png/": "untranslated",
+	"/docs/reference/png/": "translated",
 	"/docs/reference/svg/": "untranslated",
 	"/docs/guides/": "translated",
 	"/docs/guides/guide-for-latex-users/": "untranslated",


### PR DESCRIPTION
[/docs/reference/png/](https://typst.app/docs/reference/png/)の翻訳です。