### PR TITLE
`/docs/reference/introspection/location`の翻訳

### DIFF
--- a/crates/typst-library/src/introspection/location.rs
+++ b/crates/typst-library/src/introspection/location.rs
@@ -8,19 +8,17 @@ use crate::foundations::{func, scope, ty, Repr};
 use crate::layout::Position;
 use crate::model::Numbering;
 
-/// Identifies an element in the document.
+/// 文書中の要素の識別。
 ///
-/// A location uniquely identifies an element in the document and lets you
-/// access its absolute position on the pages. You can retrieve the current
-/// location with the [`here`] function and the location of a queried or shown
-/// element with the [`location()`]($content.location) method on content.
+/// locationは文書中の要素を一意に識別し、ページ中での絶対位置へのアクセスを提供します。
+/// [`here`]関数を用いて現在位置を取得可能です。
+/// また、検索した位置や表示された要素の位置はコンテンツの[`location()`]($content.location)メソッドを用いて取得可能です。
 ///
-/// # Locatable elements { #locatable }
-/// Currently, only a subset of element functions is locatable. Aside from
-/// headings and figures, this includes equations, references, quotes and all
-/// elements with an explicit label. As a result, you _can_ query for e.g.
-/// [`strong`] elements, but you will find only those that have an explicit
-/// label attached to them. This limitation will be resolved in the future.
+/// # ロケータブル要素 { #locatable }
+/// 現在、要素関数の一部のみがロケータブルです。
+/// 見出しと図表の他に、数式、参照、引用、全ての明示的なラベルを持つ要素が該当します。
+/// したがって、例えば[`strong`]要素に対してクエリが実行 _可能_ ですが、見つかるのは明示的にラベルが付けられたもののみです。
+/// この制限は将来的に解消される予定です。
 #[ty(scope)]
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
 pub struct Location(u128);
@@ -48,16 +46,13 @@ impl Location {
 
 #[scope]
 impl Location {
-    /// Returns the page number for this location.
+    /// このlocationのページ番号を返します。
     ///
-    /// Note that this does not return the value of the [page counter]($counter)
-    /// at this location, but the true page number (starting from one).
+    /// このlocationの[ページカウンター]($counter)の値を返すわけではなく、（1始まりの）実際のページ番号を返すことに注意してください。
     ///
-    /// If you want to know the value of the page counter, use
-    /// `{counter(page).at(loc)}` instead.
+    /// ページカウンターの値が知りたい場合は代わりに`{counter(page).at(loc)}`を使用してください。
     ///
-    /// Can be used with [`here`] to retrieve the physical page position
-    /// of the current context:
+    /// [`here`]と組み合わせることで現在のコンテキストが配置される実際のページ番号が取得できます。
     /// ```example
     /// #context [
     ///   I am located on
@@ -69,24 +64,20 @@ impl Location {
         engine.introspector.page(self)
     }
 
-    /// Returns a dictionary with the page number and the x, y position for this
-    /// location. The page number starts at one and the coordinates are measured
-    /// from the top-left of the page.
+    /// このlocationのページ番号とx座標とy座標を辞書で返します。
+    /// ページ番号は1始まりで、座標はページの左上から測ります。
     ///
-    /// If you only need the page number, use `page()` instead as it allows
-    /// Typst to skip unnecessary work.
+    /// ページ番号にのみ興味がある場合は、代わりに`page()`を使用すると不必要な処理を省略できます。
     #[func]
     pub fn position(self, engine: &mut Engine) -> Position {
         engine.introspector.position(self)
     }
 
-    /// Returns the page numbering pattern of the page at this location. This
-    /// can be used when displaying the page counter in order to obtain the
-    /// local numbering. This is useful if you are building custom indices or
-    /// outlines.
+    /// このlocationのページ番号の番号付けパターンを返します。
+    /// これにより、ページカウンターの表示する際に、その位置での番号付けを取得できます。
+    /// これは独自の索引やアウトラインを作成する場合に便利です。
     ///
-    /// If the page numbering is set to `{none}` at that location, this function
-    /// returns `{none}`.
+    /// その位置でのページの番号付けが`{none}`に設定されていた場合、`{none}`を返します。
     #[func]
     pub fn page_numbering(self, engine: &mut Engine) -> Option<Numbering> {
         engine.introspector.page_numbering(self).cloned()

--- a/website/translation-status.json
+++ b/website/translation-status.json
@@ -147,7 +147,7 @@
 	"/docs/reference/introspection/counter/": "untranslated",
 	"/docs/reference/introspection/here/": "untranslated",
 	"/docs/reference/introspection/locate/": "untranslated",
-	"/docs/reference/introspection/location/": "untranslated",
+	"/docs/reference/introspection/location/": "translated",
 	"/docs/reference/introspection/metadata/": "untranslated",
 	"/docs/reference/introspection/query/": "untranslated",
 	"/docs/reference/introspection/state/": "untranslated",


### PR DESCRIPTION
[introspection/location](https://typst.app/docs/reference/introspection/location)
locationの翻訳は暫定的に「位置」にしてあります。
また、locatableの訳出にも悩んでいます。とりあえずそのまま「ロケータブル」にしてありますが、「位置（情報）特定可能」とかの方が良いかもしれません。