### PR TITLE
`/docs/reference/introspection`の翻訳

### DIFF
--- a/docs/reference/library/introspection.md
+++ b/docs/reference/library/introspection.md
@@ -1,10 +1,9 @@
-Interactions between document parts.
+文書内の相互作用。
 
-This category is home to Typst's introspection capabilities: With the `counter`
-function, you can access and manipulate page, section, figure, and equation
-counters or create custom ones. Meanwhile, the `query` function lets you search
-for elements in the document to construct things like a list of figures or
-headers which show the current chapter title.
+このカテゴリーはTypstの内省機能に関するものです。
+`counter`関数を用いると、ページ、節、図表、数式のカウンターにアクセスしたり操作したりできます。
+また、独自のカウンターも作成できます。
+一方、`query`関数を用いると、図表のリストや現在の章タイトルを表示する見出しなどを作成するために、文書内の要素を探せます。
 
-Most of the functions are _contextual._ It is recommended to read the chapter on
-[context]($context) before continuing here.
+ほとんどの関数が *コンテキスト依存*です。
+先に進む前に[コンテキスト]($context)の章を読むことをおすすめします。

--- a/website/translation-status.json
+++ b/website/translation-status.json
@@ -143,7 +143,7 @@
 	"/docs/reference/visualize/square/": "untranslated",
 	"/docs/reference/visualize/stroke/": "untranslated",
 	"/docs/reference/visualize/tiling/": "untranslated",
-	"/docs/reference/introspection/": "untranslated",
+	"/docs/reference/introspection/": "translated",
 	"/docs/reference/introspection/counter/": "untranslated",
 	"/docs/reference/introspection/here/": "untranslated",
 	"/docs/reference/introspection/locate/": "untranslated",


### PR DESCRIPTION
[reference/introspection](https://typst.app/docs/reference/introspection)の翻訳です。