### PR TITLE
layout/gridの翻訳ステータスの修正

### DIFF
--- a/website/translation-status.json
+++ b/website/translation-status.json
@@ -112,7 +112,7 @@
 	"/docs/reference/layout/columns/": "translated",
 	"/docs/reference/layout/direction/": "partially_translated",
 	"/docs/reference/layout/fraction/": "translated",
-	"/docs/reference/layout/grid/": "translated",
+	"/docs/reference/layout/grid/": "partially_translated",
 	"/docs/reference/layout/hide/": "translated",
 	"/docs/reference/layout/layout/": "partially_translated",
 	"/docs/reference/layout/length/": "translated",


### PR DESCRIPTION
#242 で[layout/grid](https://typst-jp.github.io/docs/reference/layout/grid/)の翻訳を行なっていましたが、v0.14.0対応で追加された原文反映のみを行なっており、その追加翻訳が行われていません。したがって翻訳状態は部分翻訳が正確です。
現在追加分の翻訳作業を行なっており、それがマージされるまで翻訳状態を部分翻訳にするPRとなります。