### PR TITLE
`/docs/reference/math/vec/`の再翻訳

### DIFF
--- a/crates/typst-library/src/math/matrix.rs
+++ b/crates/typst-library/src/math/matrix.rs
@@ -19,9 +19,8 @@ const DEFAULT_COL_GAP: Em = Em::new(0.5);
 ///
 /// ベクトルの要素内のコンテンツは[`align`]($math.vec.align)パラメーターか`&`記号を用いて配置できます。
 ///
-/// This function is for typesetting vector components. To typeset a symbol that
-/// represents a vector, [`arrow`]($math.accent) and [`bold`]($math.bold) are
-/// commonly used.
+/// この関数はベクトルの成分を組版するためのものです。
+/// ベクトルを表す記号の組版には、[`arrow`]($math.accent)や[`bold`]($math.bold)がよく用いられます。
 ///
 /// # 例
 /// ```example

--- a/website/translation-status.json
+++ b/website/translation-status.json
@@ -98,7 +98,7 @@
 	"/docs/reference/math/op/": "translated",
 	"/docs/reference/math/underover/": "translated",
 	"/docs/reference/math/variants/": "partially_translated",
-	"/docs/reference/math/vec/": "partially_translated",
+	"/docs/reference/math/vec/": "translated",
 	"/docs/reference/symbols/": "untranslated",
 	"/docs/reference/symbols/sym/": "untranslated",
 	"/docs/reference/symbols/emoji/": "untranslated",


### PR DESCRIPTION
Closes #349