### PR TITLE
`/docs/reference/math/accent/`の再翻訳

### DIFF
--- a/crates/typst-library/src/math/accent.rs
+++ b/crates/typst-library/src/math/accent.rs
@@ -65,10 +65,9 @@ pub struct AccentElem {
     #[default(Rel::one())]
     pub size: Rel<Length>,
 
-    /// Whether to remove the dot on top of lowercase i and j when adding a top
-    /// accent.
+    /// 上付きのアクセント記号を追加する際に、小文字のiおよびjの上の点を取り除くかどうか。
     ///
-    /// This enables the `dtls` OpenType feature.
+    /// OpenTypeフィーチャーの`dtls`が有効になります。
     ///
     /// ```example
     /// $hat(dotless: #false, i)$

--- a/website/translation-status.json
+++ b/website/translation-status.json
@@ -80,7 +80,7 @@
 	"/docs/reference/text/underline/": "translated",
 	"/docs/reference/text/upper/": "translated",
 	"/docs/reference/math/": "partially_translated",
-	"/docs/reference/math/accent/": "partially_translated",
+	"/docs/reference/math/accent/": "translated",
 	"/docs/reference/math/attach/": "translated",
 	"/docs/reference/math/binom/": "translated",
 	"/docs/reference/math/cancel/": "translated",


### PR DESCRIPTION
Closes #345 