### PR TITLE
`/docs/reference/layout/stack/`の再翻訳

### DIFF
--- a/crates/typst-library/src/layout/stack.rs
+++ b/crates/typst-library/src/layout/stack.rs
@@ -17,10 +17,9 @@ use crate::layout::{Dir, Spacing};
 /// )
 /// ```
 ///
-/// # Accessibility
-/// Stacks do not carry any special semantics. The contents of the stack are
-/// read by Assistive Technology (AT) in the order in which they have been
-/// passed to this function.
+/// # アクセシビリティ
+/// スタックは特別なセマンティクスを持ちません。
+/// スタックのコンテンツは、この関数に渡された順序のまま支援技術（AT）によって読み上げられます。
 #[elem]
 pub struct StackElem {
     /// アイテムを積み重ねる向き。可能な値は以下の通りです。

--- a/website/translation-status.json
+++ b/website/translation-status.json
@@ -130,7 +130,7 @@
 	"/docs/reference/layout/skew/": "translated",
 	"/docs/reference/layout/h/": "translated",
 	"/docs/reference/layout/v/": "translated",
-	"/docs/reference/layout/stack/": "partially_translated",
+	"/docs/reference/layout/stack/": "translated",
 	"/docs/reference/visualize/": "translated",
 	"/docs/reference/visualize/circle/": "untranslated",
 	"/docs/reference/visualize/color/": "untranslated",


### PR DESCRIPTION
Closes #358