### PR TITLE
chore: miseの自動承認設定を削除

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -7,7 +7,6 @@ pinact = "3.1.1"
 jq = "1.8.1"
 
 [settings]
-yes = true
 idiomatic_version_file_enable_tools = []
 
 # As of mise v2025.11.11, the `vars` configuration does not support arrays in JSON file.


### PR DESCRIPTION
ローカル環境の`yes`はセキュリティ対策としてmise [v2026.6.5](https://github.com/jdx/mise/releases/tag/v2026.6.5)で無効化されました。それ以降のバージョンでは警告が表示されます。